### PR TITLE
[FIX]컴포넌트화

### DIFF
--- a/src/components/CalComponents/CalComponents.tsx
+++ b/src/components/CalComponents/CalComponents.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+
+import CalendarFooter from '../../components/CalendarFooter/CalendarFooter';
+import CalendarHeader from '../../components/CalendarHeader/CalendarHeader';
+import CalendarBody from '../../components/CalendarBody/CalendarBody';
+import { getDateArray } from '../../utils/convertDate';
+
+const CalComponents = ({ startDate, range }: { startDate: Date; range: number }) => {
+  const [startSelected, setstartSelected] = useState<Date | null>(null);
+  const [endSelected, setEndSelected] = useState<Date | null>(null);
+  const dateArray: Date[] = getDateArray(startDate, range);
+
+  const clickDateHandler = (date: Date | '') => {
+    if (date === '') {
+      return;
+    }
+    if (startSelected === null && endSelected === null) {
+      setstartSelected(date);
+    } else if (
+      !!startSelected &&
+      endSelected === null &&
+      (startSelected.getTime() === date.getTime() || startSelected.getTime() >= date.getTime())
+    ) {
+      setstartSelected(null);
+    } else if (!!startSelected && endSelected === null) {
+      setEndSelected(date);
+    } else if (!!startSelected && !!endSelected) {
+      setstartSelected(null);
+      setEndSelected(null);
+    }
+  };
+
+  return (
+    <>
+      {dateArray.map((date: Date) => (
+        <>
+          <CalendarHeader month={date.getMonth()} />
+          <CalendarBody
+            startDate={date}
+            startSelected={startSelected}
+            endSelected={endSelected}
+            clickDateHandler={clickDateHandler}
+          />
+        </>
+      ))}
+      {/* <CalendarBody
+        startDate={startDate}
+        startSelected={startSelected}
+        endSelected={endSelected}
+        clickDateHandler={clickDateHandler}
+      />
+      <CalendarBody
+        startDate={new Date('2023/3/3')}
+        startSelected={startSelected}
+        endSelected={endSelected}
+        clickDateHandler={clickDateHandler}
+      /> */}
+      <CalendarFooter />
+    </>
+  );
+};
+
+export default CalComponents;

--- a/src/components/CalendarBody/CalendarBody.tsx
+++ b/src/components/CalendarBody/CalendarBody.tsx
@@ -3,31 +3,20 @@ import styled, { css } from 'styled-components';
 
 const WEEKS = ['일', '월', '화', '수', '목', '금', '토'];
 
-const CalendarBody = () => {
-  const [startDate, setStartDate] = useState<Date | null>(null);
-  const [endDate, setEndDate] = useState<Date | null>(null);
+type CalendarProps = {
+  startDate: Date;
+  startSelected: Date | null;
+  endSelected: Date | null;
+  clickDateHandler: (el: Date) => void;
+};
 
-  const clickDateHandler = (date: Date | '') => {
-    if (date === '') {
-      return;
-    }
-    if (startDate === null && endDate === null) {
-      setStartDate(date);
-    } else if (
-      !!startDate &&
-      endDate === null &&
-      (startDate.getTime() === date.getTime() || startDate.getTime() >= date.getTime())
-    ) {
-      setStartDate(null);
-    } else if (!!startDate && endDate === null) {
-      setEndDate(date);
-    } else if (!!startDate && !!endDate) {
-      setStartDate(null);
-      setEndDate(null);
-    }
-  };
-
-  const today = new Date();
+const CalendarBody = ({
+  startDate,
+  startSelected,
+  endSelected,
+  clickDateHandler,
+}: CalendarProps) => {
+  const today = startDate;
   const firstDay = new Date(today.getFullYear(), today.getMonth(), 1);
   const lastDay = new Date(today.getFullYear(), today.getMonth() + 1, 0);
   const emptyDate = new Array(31).fill('');
@@ -45,7 +34,7 @@ const CalendarBody = () => {
     <CalBody>
       <Days>
         {WEEKS.map((el, idx) => (
-          <DayButton key={idx} selected={false}>
+          <DayButton key={idx} selectedStart={false} selectedEnd={false} range={false}>
             {el}
           </DayButton>
         ))}
@@ -54,9 +43,11 @@ const CalendarBody = () => {
         {totalDateArr.slice(0, 7).map((el, idx) => (
           <DayButton
             key={idx}
-            selected={
-              !!el
-                ? el?.getTime() === startDate?.getTime() || el?.getTime() === endDate?.getTime()
+            selectedStart={!!el ? el?.getTime() === startSelected?.getTime() : false}
+            selectedEnd={!!el ? el?.getTime() === endSelected?.getTime() : false}
+            range={
+              !!el && !!startSelected && !!endSelected
+                ? el?.getTime() > startSelected?.getTime() && el?.getTime() < endSelected?.getTime()
                 : false
             }
             onClick={() => clickDateHandler(el)}
@@ -69,9 +60,11 @@ const CalendarBody = () => {
         {totalDateArr.slice(7, 14).map((el, idx) => (
           <DayButton
             key={idx}
-            selected={
-              !!el
-                ? el?.getTime() === startDate?.getTime() || el?.getTime() === endDate?.getTime()
+            selectedStart={!!el ? el?.getTime() === startSelected?.getTime() : false}
+            selectedEnd={!!el ? el?.getTime() === endSelected?.getTime() : false}
+            range={
+              !!el && !!startSelected && !!endSelected
+                ? el?.getTime() > startSelected?.getTime() && el?.getTime() < endSelected?.getTime()
                 : false
             }
             onClick={() => clickDateHandler(el)}
@@ -84,9 +77,11 @@ const CalendarBody = () => {
         {totalDateArr.slice(14, 21).map((el, idx) => (
           <DayButton
             key={idx}
-            selected={
-              !!el
-                ? el?.getTime() === startDate?.getTime() || el?.getTime() === endDate?.getTime()
+            selectedStart={!!el ? el?.getTime() === startSelected?.getTime() : false}
+            selectedEnd={!!el ? el?.getTime() === endSelected?.getTime() : false}
+            range={
+              !!el && !!startSelected && !!endSelected
+                ? el?.getTime() > startSelected?.getTime() && el?.getTime() < endSelected?.getTime()
                 : false
             }
             onClick={() => clickDateHandler(el)}
@@ -99,9 +94,11 @@ const CalendarBody = () => {
         {totalDateArr.slice(21, 28).map((el, idx) => (
           <DayButton
             key={idx}
-            selected={
-              !!el
-                ? el?.getTime() === startDate?.getTime() || el?.getTime() === endDate?.getTime()
+            selectedStart={!!el ? el?.getTime() === startSelected?.getTime() : false}
+            selectedEnd={!!el ? el?.getTime() === endSelected?.getTime() : false}
+            range={
+              !!el && !!startSelected && !!endSelected
+                ? el?.getTime() > startSelected?.getTime() && el?.getTime() < endSelected?.getTime()
                 : false
             }
             onClick={() => clickDateHandler(el)}
@@ -114,9 +111,11 @@ const CalendarBody = () => {
         {totalDateArr.slice(28, 35).map((el, idx) => (
           <DayButton
             key={idx}
-            selected={
-              !!el
-                ? el?.getTime() === startDate?.getTime() || el?.getTime() === endDate?.getTime()
+            selectedStart={!!el ? el?.getTime() === startSelected?.getTime() : false}
+            selectedEnd={!!el ? el?.getTime() === endSelected?.getTime() : false}
+            range={
+              !!el && !!startSelected && !!endSelected
+                ? el?.getTime() > startSelected?.getTime() && el?.getTime() < endSelected?.getTime()
                 : false
             }
             onClick={() => clickDateHandler(el)}
@@ -137,6 +136,7 @@ const CalBody = styled.main`
   flex-direction: column;
   flex: 7;
   width: 100%;
+  margin-bottom: 10px;
 `;
 
 const Days = styled.div`
@@ -148,7 +148,7 @@ const Days = styled.div`
   background-color: bisque;
 `;
 
-const DayButton = styled.div<{ selected: boolean }>`
+const DayButton = styled.div<{ selectedStart: boolean; range: boolean; selectedEnd: boolean }>`
   flex: 1;
   position: relative;
   width: 40px;
@@ -157,9 +157,8 @@ const DayButton = styled.div<{ selected: boolean }>`
   text-align: center;
   line-height: 40px;
   z-index: 10;
-  ${({ selected }) => {
-    console.log(selected);
-    if (selected) {
+  ${({ selectedStart, selectedEnd }) => {
+    if (selectedStart) {
       return css`
         ::before {
           content: '';
@@ -173,8 +172,53 @@ const DayButton = styled.div<{ selected: boolean }>`
           background-color: beige;
           z-index: -2;
         }
-        /* border-radius: 50%; */
-        /* background-color: bisque; */
+        ::after {
+          content: '';
+          display: block;
+          position: absolute;
+          right: -30%;
+          top: 0;
+          transform: translateX(-50%);
+          width: 30px;
+          height: 40px;
+          background-color: beige;
+          z-index: -2;
+        }
+      `;
+    }
+    if (selectedEnd) {
+      return css`
+        ::before {
+          content: '';
+          display: block;
+          position: absolute;
+          left: 50%;
+          transform: translateX(-50%);
+          width: 40px;
+          height: 40px;
+          border-radius: 50%;
+          background-color: beige;
+          z-index: -2;
+        }
+        ::after {
+          content: '';
+          display: block;
+          position: absolute;
+          left: 0;
+          top: 0;
+          transform: translateX(-50%);
+          width: 40px;
+          height: 40px;
+          background-color: beige;
+          z-index: -2;
+        }
+      `;
+    }
+  }}
+  ${({ range }) => {
+    if (range) {
+      return css`
+        background-color: beige;
       `;
     }
   }}

--- a/src/components/CalendarHeader/CalendarHeader.tsx
+++ b/src/components/CalendarHeader/CalendarHeader.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const CalendarHeader = () => {
-  return <CalHeader>머리</CalHeader>;
+const CalendarHeader = ({ month }: { month: number }) => {
+  return <CalHeader>{month} 월</CalHeader>;
 };
 
 export default CalendarHeader;
 
 const CalHeader = styled.header`
-  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 60px;
   width: 100%;
+  font-size: 20px;
+  font-weight: 700;
 `;

--- a/src/pages/Calendar/Calendar.tsx
+++ b/src/pages/Calendar/Calendar.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
-import CalendarFooter from '../../components/CalendarFooter/CalendarFooter';
-import CalendarHeader from '../../components/CalendarHeader/CalendarHeader';
-import CalendarBody from '../../components/CalendarBody/CalendarBody';
+import CalComponents from '../../components/CalComponents/CalComponents';
+
 const Calendar = () => {
   return (
     <CalendarWrapper>
       <CalendarContainer>
-        <CalendarHeader />
-        <CalendarBody />
-        <CalendarFooter />
+        <CalComponents startDate={new Date()} range={3} />
       </CalendarContainer>
     </CalendarWrapper>
   );
@@ -27,11 +24,10 @@ const CalendarWrapper = styled.div`
 `;
 
 const CalendarContainer = styled.div`
-  display: flex;
-  flex-direction: column;
   width: 400px;
   height: 600px;
   border-radius: 20px;
   box-shadow: 5px 5px rgb(150, 150, 150);
   background-color: white;
+  overflow: scroll;
 `;

--- a/src/utils/convertDate.ts
+++ b/src/utils/convertDate.ts
@@ -1,0 +1,17 @@
+export const DateToString = ({ date, type }: { date: Date; type: string }) => {
+  const years = date.getFullYear();
+  const months = date.getMonth();
+  const dates = date.getDate();
+  return `${years}${type}${months}${type}${dates}`;
+};
+
+export const StringToDate = ({ dateString }: { dateString: string }) => {
+  return new Date(dateString);
+};
+
+export const getDateArray = (date: Date, range: number): Date[] => {
+  const emptyArray = new Array(range).fill('');
+  const dateArr = emptyArray.map((el, idx) => date.getMonth() + idx);
+
+  return dateArr.map(el => new Date(new Date().setMonth(el)));
+};


### PR DESCRIPTION
달력의 시작일과, 보여질 달의 범위(range) 를 세팅하고 시작일과 range에 따라

range만큼의 배열을 만들고 해당 배열의 요소는 시작일과 그에 따른 월(Month)수를 추가하여 배열을 만들어

달력을 만들고, 각각의 달력에서 state를 관리하는게 아닌, 부모 컴포넌트에서 state를 관리하고 각각의 달력에

prop으로 전해주어,  전체적인 범위의 달력에서 시작과 끝 날짜를 선택할 수 있도록 세팅하였습니다.